### PR TITLE
Add missing requirements.txt to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,5 @@
 include LICENSE
 include README.md
+include requirements.txt
 include dev-requirements.txt
-include fideslib/cryptography/requirements.txt
-include fideslib/oauth/requirements.txt
 include fideslib/py.typed

--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,7 @@ from setuptools import setup
 
 
 def read_requirements(filename: str) -> List[str]:
-    """
-    Returns the contents of a requirements file, as a list.
-    """
+    """Returns the contents of a requirements file, as a list."""
 
     with open(filename, "r") as file:
         requirements = file.read().strip().split("\n")


### PR DESCRIPTION
The MANIFEST.in file was not updated to point to the new location of the `requirements.txt` file causing an error on `pip install fideslib`.