### PR TITLE
Set default value for encoding in validator

### DIFF
--- a/fides.toml
+++ b/fides.toml
@@ -1,10 +1,3 @@
-# [database]
-# SERVER="db"
-# USER="postgres"
-# PASSWORD="216f4b49bea5da4f84f05288258471852c3e325cd336821097e1e65ff92b528a"
-# DB="app"
-# TEST_DB="test"
-
 [database]
 SERVER="localhost"
 USER="postgres"

--- a/fideslib/core/config.py
+++ b/fideslib/core/config.py
@@ -142,7 +142,7 @@ class SecuritySettings(FidesSettings):
                 "OAUTH_ROOT_CLIENT_SECRET is required", SecuritySettings
             )
 
-        encoding = values["ENCODING"]
+        encoding = values.get("ENCODING", "UTF-8")
 
         salt = bcrypt.gensalt()
         hashed_client_id = hashlib.sha512(value.encode(encoding) + salt).hexdigest()

--- a/tests/assets/fides.toml
+++ b/tests/assets/fides.toml
@@ -1,0 +1,13 @@
+[database]
+SERVER="testserver"
+USER="postgres"
+PASSWORD="postgres"
+DB="test"
+TEST_DB="test"
+
+[security]
+APP_ENCRYPTION_KEY = "atestencryptionkeythatisvalidlen"
+CORS_ORIGINS = [ "http://test.com", "https://test.com",]
+OAUTH_ROOT_CLIENT_ID = "testrootclientid"
+OAUTH_ROOT_CLIENT_SECRET = "testrootclientsecret"
+DRP_JWT_SECRET = "testdrpsecret"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,8 @@
 # pylint: disable=missing-function-docstring, redefined-outer-name
 
+import os
+from unittest.mock import patch
+
 import pytest
 
 from fideslib.core.config import (
@@ -14,6 +17,20 @@ from fideslib.exceptions import MissingConfig
 @pytest.fixture
 def config_dict(fides_toml_path):
     yield load_toml([fides_toml_path])
+
+
+@patch.dict(
+    os.environ,
+    {
+        "FIDES__CONFIG_PATH": "tests/assets",
+    },
+    clear=True,
+)
+def test_config_from_path() -> None:
+    """Test reading config using the FIDESOPS__CONFIG_PATH option."""
+    config = get_config()
+    assert config.database.SERVER == "testserver"
+    assert config.security.APP_ENCRYPTION_KEY == "atestencryptionkeythatisvalidlen"
 
 
 def test_database_settings_sqlalchemy_database_uri_str(config_dict):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,7 @@
 # pylint: disable=missing-function-docstring, redefined-outer-name
 
 import os
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -13,6 +14,8 @@ from fideslib.core.config import (
 )
 from fideslib.exceptions import MissingConfig
 
+ROOT_PATH = Path().absolute()
+
 
 @pytest.fixture
 def config_dict(fides_toml_path):
@@ -22,7 +25,7 @@ def config_dict(fides_toml_path):
 @patch.dict(
     os.environ,
     {
-        "FIDES__CONFIG_PATH": "tests/assets",
+        "FIDES__CONFIG_PATH": str(ROOT_PATH / "tests" / "assets"),
     },
     clear=True,
 )


### PR DESCRIPTION
Fixes #19

Default values in pydantic don't seem to be available to the `root_validator` so `ENCODING` was throwing and error when it was not present in the toml file. This fixes the issue by setting the default value in the validator when the value is missing.