### PR TITLE
Check 2 directories up for toml file to allow new location in fidesops

### DIFF
--- a/fideslib/core/config.py
+++ b/fideslib/core/config.py
@@ -176,6 +176,7 @@ def load_file(file_names: Union[List[Path], List[str]]) -> str:
     - A path set at ENV variable FIDES__CONFIG_PATH
     - The current directory
     - The parent directory
+    - Two directories up for the current directory
     - The parent_directory/.fides
     - users home (~) directory
     raises FileNotFound if none is found
@@ -185,6 +186,7 @@ def load_file(file_names: Union[List[Path], List[str]]) -> str:
         os.getenv("FIDES__CONFIG_PATH"),
         os.curdir,
         os.pardir,
+        os.path.abspath(os.path.join(os.curdir, "..", "..")),
         os.path.join(os.pardir, ".fides"),
         os.path.expanduser("~"),
     ]


### PR DESCRIPTION
Now that the `alembic.ini` file is in the `src/fidesops` directory in fidesops, `load_file` was not able to find the `fidesops.toml` file when running alembic commands. `load_file` now also checks two directories up for the toml file.