### PR TITLE
Allow config and scopes to be passed to client

### DIFF
--- a/fideslib/models/client.py
+++ b/fideslib/models/client.py
@@ -94,6 +94,10 @@ class ClientDetail(Base):
     ) -> ClientDetail | None:
         """Fetch a database record via a client_id"""
         if object_id == config.security.OAUTH_ROOT_CLIENT_ID:
+            if not scopes:
+                raise ValueError(
+                    "Scopes are required when using the OAUTH_ROOT_CLIENT_ID"
+                )
             return _get_root_client_detail(config, scopes)
         return super().get(db, object_id=object_id)
 
@@ -119,14 +123,11 @@ class ClientDetail(Base):
 
 def _get_root_client_detail(
     config: FidesConfig,
-    scopes: list[str] | None = None,
+    scopes: list[str],
     encoding: str = "UTF-8",
 ) -> ClientDetail | None:
     if not config.security.OAUTH_ROOT_CLIENT_SECRET_HASH:
         raise ValueError("A root client hash is required")
-
-    if not scopes:
-        raise ValueError("Scopes are required")
 
     return ClientDetail(
         id=config.security.OAUTH_ROOT_CLIENT_ID,

--- a/fideslib/oauth/api/deps.py
+++ b/fideslib/oauth/api/deps.py
@@ -53,10 +53,4 @@ def verify_oauth_client(
     by the installing library.
     """
     config = core_get_config()
-    return verify(
-        security_scopes,
-        authorization,
-        db=db,
-        token_duration_min=config.security.OAUTH_ACCESS_TOKEN_EXPIRE_MINUTES,
-        encryption_key=config.security.APP_ENCRYPTION_KEY,
-    )
+    return verify(security_scopes, authorization, db=db, config=config)

--- a/tests/test_client_model.py
+++ b/tests/test_client_model.py
@@ -46,6 +46,11 @@ def test_get_client_root_client(db, config):
     assert client.scopes == SCOPES
 
 
+def test_get_client_root_client_no_scopes(db, config):
+    with pytest.raises(ValueError):
+        ClientDetail.get(db, object_id="fidesadmin", config=config)
+
+
 def test_credentials_valid(db, config):
     new_client, secret = ClientDetail.create_client_and_secret(
         db,
@@ -63,8 +68,3 @@ def test_get_root_client_detail_no_root_client_hash(config):
     test_config.security.OAUTH_ROOT_CLIENT_SECRET_HASH = None
     with pytest.raises(ValueError):
         _get_root_client_detail(test_config, SCOPES)
-
-
-def test_get_root_client_detail_no_scopes(config):
-    with pytest.raises(ValueError):
-        _get_root_client_detail(config)

--- a/tests/test_client_model.py
+++ b/tests/test_client_model.py
@@ -38,6 +38,7 @@ def test_get_client_root_client(db, config):
         object_id="fidesadmin",
         root_client_id=config.security.OAUTH_ROOT_CLIENT_ID,
         root_client_hash=config.security.OAUTH_ROOT_CLIENT_SECRET_HASH,
+        scopes=SCOPES,
     )
     assert client
     assert client.id == config.security.OAUTH_ROOT_CLIENT_ID
@@ -49,6 +50,7 @@ def test_credentials_valid(db, config):
         db,
         config.security.OAUTH_CLIENT_ID_LENGTH_BYTES,
         config.security.OAUTH_CLIENT_SECRET_LENGTH_BYTES,
+        scopes=SCOPES,
     )
 
     assert new_client.credentials_valid("this-is-not-the-right-secret") is False
@@ -57,4 +59,9 @@ def test_credentials_valid(db, config):
 
 def test_get_root_client_detail_no_root_client_hash():
     with pytest.raises(ValueError):
-        _get_root_client_detail("test", None)
+        _get_root_client_detail("test", None, SCOPES)
+
+
+def test_get_root_client_detail_no_scopes(config):
+    with pytest.raises(ValueError):
+        _get_root_client_detail("test", config.security.OAUTH_ROOT_CLIENT_SECRET_HASH)

--- a/tests/test_client_model.py
+++ b/tests/test_client_model.py
@@ -1,5 +1,7 @@
 # pylint: disable=missing-function-docstring
 
+from copy import deepcopy
+
 import pytest
 
 from fideslib.cryptography.cryptographic_util import hash_with_salt
@@ -24,8 +26,8 @@ def test_create_client_and_secret(db, config):
     )
 
 
-def test_get_client(db, oauth_client):
-    client = ClientDetail.get(db, object_id=oauth_client.id)
+def test_get_client(db, oauth_client, config):
+    client = ClientDetail.get(db, object_id=oauth_client.id, config=config)
     assert client
     assert client.id == oauth_client.id
     assert client.scopes == SCOPES
@@ -36,8 +38,7 @@ def test_get_client_root_client(db, config):
     client = ClientDetail.get(
         db,
         object_id="fidesadmin",
-        root_client_id=config.security.OAUTH_ROOT_CLIENT_ID,
-        root_client_hash=config.security.OAUTH_ROOT_CLIENT_SECRET_HASH,
+        config=config,
         scopes=SCOPES,
     )
     assert client
@@ -57,11 +58,13 @@ def test_credentials_valid(db, config):
     assert new_client.credentials_valid(secret) is True
 
 
-def test_get_root_client_detail_no_root_client_hash():
+def test_get_root_client_detail_no_root_client_hash(config):
+    test_config = deepcopy(config)
+    test_config.security.OAUTH_ROOT_CLIENT_SECRET_HASH = None
     with pytest.raises(ValueError):
-        _get_root_client_detail("test", None, SCOPES)
+        _get_root_client_detail(test_config, SCOPES)
 
 
 def test_get_root_client_detail_no_scopes(config):
     with pytest.raises(ValueError):
-        _get_root_client_detail("test", config.security.OAUTH_ROOT_CLIENT_SECRET_HASH)
+        _get_root_client_detail(config)

--- a/tests/test_oauth_util.py
+++ b/tests/test_oauth_util.py
@@ -61,8 +61,7 @@ def test_verify_oauth_client_no_issued_at(db, config, user):
             SecurityScopes([USER_READ]),
             token,
             db=db,
-            token_duration_min=1,
-            encryption_key=config.security.APP_ENCRYPTION_KEY,
+            config=config,
         )
 
 
@@ -83,8 +82,7 @@ def test_verify_oauth_client_expired(db, config, user):
             SecurityScopes(scope),
             token,
             db=db,
-            token_duration_min=1,
-            encryption_key=config.security.APP_ENCRYPTION_KEY,
+            config=config,
         )
 
 
@@ -105,8 +103,7 @@ def test_verify_oauth_client_no_client_id(db, config):
             SecurityScopes(scope),
             token,
             db=db,
-            token_duration_min=1,
-            encryption_key=config.security.APP_ENCRYPTION_KEY,
+            config=config,
         )
 
 
@@ -125,13 +122,7 @@ def test_verify_oauth_client_no_client(db, config, user):
     user.client.delete(db)
     assert user.client is None
     with pytest.raises(AuthorizationError):
-        verify_oauth_client(
-            SecurityScopes(scopes),
-            token,
-            db=db,
-            token_duration_min=1,
-            encryption_key=config.security.APP_ENCRYPTION_KEY,
-        )
+        verify_oauth_client(SecurityScopes(scopes), token, db=db, config=config)
 
 
 def test_verify_oauth_client_wrong_security_scope(db, config, user):
@@ -146,13 +137,7 @@ def test_verify_oauth_client_wrong_security_scope(db, config, user):
         config.security.APP_ENCRYPTION_KEY,
     )
     with pytest.raises(AuthorizationError):
-        verify_oauth_client(
-            SecurityScopes([USER_READ]),
-            token,
-            db=db,
-            token_duration_min=1,
-            encryption_key=config.security.APP_ENCRYPTION_KEY,
-        )
+        verify_oauth_client(SecurityScopes([USER_READ]), token, db=db, config=config)
 
 
 def test_verify_oauth_client_wrong_client_scope(db, config, user):
@@ -173,6 +158,5 @@ def test_verify_oauth_client_wrong_client_scope(db, config, user):
             SecurityScopes(scopes),
             token,
             db=db,
-            token_duration_min=1,
-            encryption_key=config.security.APP_ENCRYPTION_KEY,
+            config=config,
         )


### PR DESCRIPTION
Fixes #29

Also takes the full config as an argument. This is needed to properly handle the usage of root client id.

