### PR TITLE
Make reading of environment variables case insensitive

### DIFF
--- a/fideslib/core/config.py
+++ b/fideslib/core/config.py
@@ -173,9 +173,9 @@ class FidesConfig(FidesSettings):
     database: DatabaseSettings
     security: SecuritySettings
 
-    is_test_mode: bool = os.getenv("TESTING") == "True"
-    hot_reloading: bool = os.getenv("FIDES__HOT_RELOAD") == "True"
-    dev_mode: bool = os.getenv("FIDES__DEV_MODE") == "True"
+    is_test_mode: bool = os.getenv("TESTING", "").lower() == "true"
+    hot_reloading: bool = os.getenv("FIDES__HOT_RELOAD", "").lower() == "true"
+    dev_mode: bool = os.getenv("FIDES__DEV_MODE", "").lower() == "true"
 
     class Config:
         case_sensitive = True


### PR DESCRIPTION
Makes the reading of the boolean environment variables case insensitive.

Related to this issue: https://github.com/ethyca/fidesops/issues/710