### PR TITLE
Add "email_sent" AuditLog.

### DIFF
--- a/fideslib/models/audit_log.py
+++ b/fideslib/models/audit_log.py
@@ -12,6 +12,7 @@ class AuditLogAction(str, EnumType):
 
     approved = "approved"
     denied = "denied"
+    email_sent = "email_sent"
     finished = "finished"
 
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ install_requires = read_requirements("requirements.txt")
 
 setup(
     name="fideslib",
-    version="3.1.0",
+    version="3.1.1",
     description="Shared libraries, for use in any fides project.",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
# What

Add a new AuditLogAction called `email_sent`


# Why
Supports https://github.com/ethyca/fidesops/issues/1158

For the new EmailConnector, for each node, we will cache the details for the email, but then combine them into one email send per dataset at the end of the privacy request. We'd like to add an AuditLog for this action.