### PR TITLE
Handling Invalid Tokens [#1257]

### DIFF
--- a/fideslib/oauth/oauth_util.py
+++ b/fideslib/oauth/oauth_util.py
@@ -42,15 +42,14 @@ def verify_oauth_client(
 
     Raises a 403 forbidden error if not.
     """
-    token_data = json.loads(
-        extract_payload(authorization, config.security.app_encryption_key)
-    )
-
     try:
-        issued_at = token_data.get(JWE_ISSUED_AT, None)
+        token_data = json.loads(
+            extract_payload(authorization, config.security.app_encryption_key)
+        )
     except exceptions.JWEParseError as exc:
         raise AuthorizationError(detail="Not Authorized for this action") from exc
 
+    issued_at = token_data.get(JWE_ISSUED_AT, None)
     if not issued_at:
         raise AuthorizationError(detail="Not Authorized for this action")
 

--- a/fideslib/oauth/oauth_util.py
+++ b/fideslib/oauth/oauth_util.py
@@ -46,7 +46,11 @@ def verify_oauth_client(
         extract_payload(authorization, config.security.app_encryption_key)
     )
 
-    issued_at = token_data.get(JWE_ISSUED_AT, None)
+    try:
+        issued_at = token_data.get(JWE_ISSUED_AT, None)
+    except jose.exceptions.JWEParseError:
+        raise AuthorizationError(detail="Not Authorized for this action")
+
     if not issued_at:
         raise AuthorizationError(detail="Not Authorized for this action")
 

--- a/fideslib/oauth/oauth_util.py
+++ b/fideslib/oauth/oauth_util.py
@@ -4,7 +4,7 @@ import json
 from datetime import datetime
 
 from fastapi.security import SecurityScopes
-from jose import jwe
+from jose import exceptions, jwe
 from sqlalchemy.orm import Session
 
 from fideslib.core.config import FidesConfig
@@ -48,8 +48,8 @@ def verify_oauth_client(
 
     try:
         issued_at = token_data.get(JWE_ISSUED_AT, None)
-    except jose.exceptions.JWEParseError:
-        raise AuthorizationError(detail="Not Authorized for this action")
+    except exceptions.JWEParseError as exc:
+        raise AuthorizationError(detail="Not Authorized for this action") from exc
 
     if not issued_at:
         raise AuthorizationError(detail="Not Authorized for this action")

--- a/fideslib/oauth/scopes.py
+++ b/fideslib/oauth/scopes.py
@@ -24,8 +24,10 @@ STORAGE = "storage"
 SYSTEM = "system"
 TAXONOMY = "taxonomy"
 UPDATE = "update"
+UPLOAD_DATA = "upload_data"
 USER = "user"
 USER_PERMISSION = "user-permission"
+VIEW_DATA = "view_data"
 WEBHOOK = "webhook"
 
 CONFIG_READ = f"{CONFIG}:{READ}"
@@ -62,6 +64,8 @@ PRIVACY_REQUEST_CALLBACK_RESUME = f"{PRIVACY_REQUEST}:{RESUME}"  # User has perm
 PRIVACY_REQUEST_DELETE = f"{PRIVACY_REQUEST}:{DELETE}"
 PRIVACY_REQUEST_READ = f"{PRIVACY_REQUEST}:{READ}"
 PRIVACY_REQUEST_REVIEW = f"{PRIVACY_REQUEST}:{REVIEW}"
+PRIVACY_REQUEST_UPLOAD_DATA = f"{PRIVACY_REQUEST}:{UPLOAD_DATA}"
+PRIVACY_REQUEST_VIEW_DATA = f"{PRIVACY_REQUEST}:{VIEW_DATA}"
 
 RULE_CREATE_OR_UPDATE = f"{RULE}:{CREATE_OR_UPDATE}"
 RULE_DELETE = f"{RULE}:{DELETE}"
@@ -125,6 +129,8 @@ SCOPE_DOCS = {
     PRIVACY_REQUEST_DELETE: "Remove privacy requests",
     PRIVACY_REQUEST_READ: "View privacy requests",
     PRIVACY_REQUEST_REVIEW: "Review privacy requests",
+    PRIVACY_REQUEST_UPLOAD_DATA: "Manually upload data for the privacy request",
+    PRIVACY_REQUEST_VIEW_DATA: "View subject data related to the privacy request",
     RESET_PASSWORD: "Reset user password",
     RULE_CREATE_OR_UPDATE: "Create or update rules",
     RULE_DELETE: "Remove rules",

--- a/tests/test_oauth_util.py
+++ b/tests/test_oauth_util.py
@@ -49,7 +49,7 @@ def test_verify_oauth_malformed_oauth_client(db, config):
     with pytest.raises(AuthorizationError):
         verify_oauth_client(
             SecurityScopes([USER_READ]),
-            "invalid",
+            authorization="invalid",
             db=db,
             config=config,
         )

--- a/tests/test_oauth_util.py
+++ b/tests/test_oauth_util.py
@@ -45,6 +45,16 @@ def test_is_token_expired(issued_at, token_duration_min, expected):
     assert is_token_expired(issued_at, token_duration_min) is expected
 
 
+def test_verify_oauth_malformed_oauth_client(db, config, user):
+    with pytest.raises(AuthorizationError):
+        verify_oauth_client(
+            SecurityScopes([USER_READ]),
+            "invalid",
+            db=db,
+            config=config,
+        )
+
+
 def test_verify_oauth_client_no_issued_at(db, config, user):
     payload = {
         JWE_PAYLOAD_SCOPES: [USER_READ],

--- a/tests/test_oauth_util.py
+++ b/tests/test_oauth_util.py
@@ -45,7 +45,7 @@ def test_is_token_expired(issued_at, token_duration_min, expected):
     assert is_token_expired(issued_at, token_duration_min) is expected
 
 
-def test_verify_oauth_malformed_oauth_client(db, config, user):
+def test_verify_oauth_malformed_oauth_client(db, config):
     with pytest.raises(AuthorizationError):
         verify_oauth_client(
             SecurityScopes([USER_READ]),


### PR DESCRIPTION
# Purpose 

Invalid tokens should be captured as a 403 error on the server, even if they are structurally incorrect.

# Changes

Raise an AuthorizationError if we get a JWEParseError when parsing the supplied token_data.

- Also add some new scopes while I'm here.


# Fixes

Fix for the second issue raised in https://github.com/ethyca/fidesops/issues/1257 
Adds scopes introduced in https://github.com/ethyca/fidesops/pull/1285