### PR TITLE
adds `fidesplus:enabled` token scope, give to all new users automatically

### DIFF
--- a/fideslib/oauth/api/routes/user_endpoints.py
+++ b/fideslib/oauth/api/routes/user_endpoints.py
@@ -32,6 +32,7 @@ from fideslib.oauth.schemas.user import (
     UserResponse,
 )
 from fideslib.oauth.scopes import (
+    FIDESPLUS_ENABLED,
     PRIVACY_REQUEST_READ,
     USER_CREATE,
     USER_DELETE,
@@ -82,7 +83,14 @@ def create_user(
     user = FidesUser.create(db=db, data=user_data.dict())
     logger.info("Created user with id: '%s'.", user.id)
     FidesUserPermissions.create(
-        db=db, data={"user_id": user.id, "scopes": [PRIVACY_REQUEST_READ]}
+        db=db,
+        data={
+            "user_id": user.id,
+            "scopes": [
+                FIDESPLUS_ENABLED,
+                PRIVACY_REQUEST_READ,
+            ],
+        },
     )
     return user
 

--- a/fideslib/oauth/scopes.py
+++ b/fideslib/oauth/scopes.py
@@ -7,9 +7,11 @@ CREATE = "create"
 CREATE_OR_UPDATE = "create_or_update"
 DATASET = "dataset"
 DELETE = "delete"
+ENABLED = "enabled"
 ENCRYPTION = "encryption"
 EXEC = "exec"
 FIDES_TAXONOMY = "fides_taxonomy"
+FIDESPLUS = "fidesplus"
 ORGANIZATION = "organization"
 POLICY = "policy"
 PRIVACY_REQUEST = "privacy-request"
@@ -51,6 +53,8 @@ DATASET_READ = f"{DATASET}:{READ}"
 ENCRYPTION_EXEC = f"{ENCRYPTION}:{EXEC}"
 
 FIDES_TAXONOMY_UPDATE = f"{FIDES_TAXONOMY}:{UPDATE}"
+
+FIDESPLUS_ENABLED = f"{FIDESPLUS}:{ENABLED}"
 
 ORGANIZATION_CREATE = f"{ORGANIZATION}:{CREATE}"
 ORGANIZATION_UPDATE = f"{ORGANIZATION}:{UPDATE}"
@@ -119,6 +123,7 @@ SCOPE_DOCS = {
     DATASET_READ: "View datasets",
     ENCRYPTION_EXEC: "Encrypt data",
     FIDES_TAXONOMY_UPDATE: "Update default fides taxonomy description",
+    FIDESPLUS_ENABLED: "Submit requests to a fidesplus server",
     ORGANIZATION_CREATE: "Create organization",
     ORGANIZATION_DELETE: "Delete organization",
     ORGANIZATION_UPDATE: "Update organization details",


### PR DESCRIPTION
This PR gives the new `fidesplus:enabled` scope to all new users, so that they may communicate with the server should it be `fidesplus`.